### PR TITLE
"Your personal data bar" section updates

### DIFF
--- a/pages/documents/Agent and manager workspace/agent tools for messaging/agent-workspace-basics.md
+++ b/pages/documents/Agent and manager workspace/agent tools for messaging/agent-workspace-basics.md
@@ -25,12 +25,15 @@ There are three main tabs that you will use as a messaging agent: **Open Connect
 
 The data bar in your workspace will represent the queue data that is relevant only to you and your conversations for the current shift. Here you will see real-time data including:
 
-* **Number of open conversations** - These are the open conversations you still need to handle
-* **Pending action** - The number of conversations that are pending your immediate reply
-* **Unassigned** - Conversations in the queue that are not yet assigned an agent, this figure will provide visibility into upcoming workloads
-* **Overdue** - Number of conversations that have passed the SLA deadline for reply
-* **Soon to be overdue** - Number of conversations that are within 5 min of surpassing the SLA deadline
-* **CSAT** - Average [CSAT](http://oavrxoiy0ht8aq.instant.forestry.io/contact-center-management-messaging-operations-benchmarks-to-measure-messaging-success.html#2-customer-satisfaction-score-csat) assigned to you from all the conversations conducted in the current shift
+**OPEN -** displays the total number of current open conversations.
+
+**PENDING** - displays the total number of conversations pending your response.
+
+**OVERDUE** - displays the total number of conversations that exceeded your target response time.
+
+**SOON TO BE OVERDUE** - displays the total number of conversations about to exceed the target response time in 5 minutes.
+
+**CSAT** - displays the customer satisfaction score, based on surveys that were completed in the last 12 hours. The calculation is (Total number of positive answers) / (Total number of answers).
 
 ## Beginning your shift
 


### PR DESCRIPTION
Changes after customer feedback.

1. The naming convention is inconsistent with LE and another documentation pages e.g. https://knowledge.liveperson.com/data-reporting-messaging-real-time-data-real-time-data-for-messaging.html#real-time-data-bar 

I adjusted it.

2. Definitions are inconsistent with other pages. I adjusted them to reflect https://knowledge.liveperson.com/data-reporting-messaging-real-time-data-real-time-data-for-messaging.html#real-time-data-bar which is more accurate.

3. It lists "Unassigned" even though agents don't see it. It raised questions from the customer. Only agent managers see it and it's split to two other KPI-s now, actionable and in the queue. I removed it from this page because addition to agent workspace is not on the roadmap so far.

4. The section doesn't highlight that Overdue and Soon to be Overdue is relevant only to the agent. Customer raised a question about whether they are for the team or agent only. I know that it's above but I added "your" to the description to make this clear.