### PR TITLE
Rename faas to functions

### DIFF
--- a/pages/documents/Developer Tools/function-as-a-service-faas.md
+++ b/pages/documents/Developer Tools/function-as-a-service-faas.md
@@ -11,7 +11,7 @@ isTutorial: false
 isNew: true
 
 ---
-LivePerson’s open platform new initiative, offers “Functions” - a Function as a Service (FaaS) platform that lets brands develop custom behaviors within the LivePerson platform to better tailor the conversational platform to their needs. This allows brands to:
+LivePerson’s open platform new initiative, offers “[Functions](https://faas.liveperson.net)” - a Function as a Service (FaaS) platform that lets brands develop custom behaviors within the LivePerson platform to better tailor the conversational platform to their needs. This allows brands to:
 
 ### Rapidly build, test and deploy new conversational experiences
 

--- a/pages/documents/Developer Tools/function-as-a-service-faas.md
+++ b/pages/documents/Developer Tools/function-as-a-service-faas.md
@@ -1,9 +1,9 @@
 ---
-pagename: Function as a Service (FaaS)
+pagename: Functions
 categoryName: Getting started
 subCategoryName: ''
 indicator: both
-subtitle: FaaS enables brands to quickly and easily customize how the LivePerson platform
+subtitle: LivePerson Functions enables brands to quickly and easily customize how the LivePerson platform
   behaves.
 level3: ''
 permalink: developer-tools-function-as-a-service-(faas).html
@@ -11,19 +11,19 @@ isTutorial: false
 isNew: true
 
 ---
-LivePerson’s open platform new initiative, offers Function as a Service (FaaS) - a service that lets brands develop custom behaviors within the LivePerson platform to better tailor the conversational platform to their needs. This allows brands to:
+LivePerson’s open platform new initiative, offers “Functions” - a Function as a Service (FaaS) platform that lets brands develop custom behaviors within the LivePerson platform to better tailor the conversational platform to their needs. This allows brands to:
 
 ### Rapidly build, test and deploy new conversational experiences
 
-Using FaaS, brands can quickly and easily extend LivePerson’s conversational commerce platform by triggering custom code as a reaction to platform events, such as creating alerts or passing data as a reaction to the change in the status of conversation. FaaS doesn’t only make it easier, but allows for a faster time to production for custom code.
+Using Functions, brands can quickly and easily extend LivePerson’s conversational commerce platform by triggering custom code as a reaction to platform events, such as creating alerts or passing data as a reaction to the change in the status of conversation. Functions doesn’t only make it easier, but allows for a faster time to production for custom code.
 
 ### Customize how LivePerson’s platform reacts to specific events
 
-FaaS enables developers to write a simple function, deploy it to LivePerson's infrastructure and go live in a matter of minutes. This resolves the complexity that brands usually encounter when they need to customize a solution to address specific unique business needs.
+Functions enables developers to write a simple function, deploy it to LivePerson's infrastructure and go live in a matter of minutes. This resolves the complexity that brands usually encounter when they need to customize a solution to address specific unique business needs.
 
 ### Optimize functions quickly, with no lag time or lengthy deployment cycles
 
-FaaS does not require brands to spin up a new service, create new APIs, set up and monitor new servers or manage security risks. Rather, FaaS processes a brand’s unique code while monitoring and maintaining the infrastructure, and scaling automatically.
+Functions does not require brands to spin up a new service, create new APIs, set up and monitor new servers or manage security risks. Rather, Functions processes a brand’s unique code while monitoring and maintaining the infrastructure, and scaling automatically.
 
 ### Eliminate the need for storage and code security
 
@@ -31,9 +31,9 @@ Since all functions are saved within the LivePerson cloud, brands do not have to
 
 ![](img/FaaS.gif)
 
-## What is FaaS?
+## What is LivePerson Functions?
 
-FaaS is a service allows brands to write their own custom behavior - through code - that is triggered by events. **Events,** include external innovations and internal LivePerson platform events, such as the start of a conversation, keyword recognition, off-hours detection and even custom bot events.
+Functions allows brands to write their own custom behavior - through code - that is triggered by events. **Events,** include external innovations and internal LivePerson platform events, such as the start of a conversation, keyword recognition, off-hours detection and even custom bot events.
 
 Brands can deploy the code as a **function** and have the custom behavior become a part of their conversational commerce platform. A **function** is the canvas, where brands can put in the code they want, to ultimately invoke a desired action or outcome.
 
@@ -43,7 +43,7 @@ The full picture of an event invoking a function can be: an account is tailored 
 
 ## Popular use cases
 
-Since FaaS allows brands to write custom, the number and variety of use cases are endless. Here are a few popular, real-life use cases:
+Since Functions allows brands to write custom, the number and variety of use cases are endless. Here are a few popular, real-life use cases:
 
 ### **Use case 1: Trigger actions based on specific intents**
 
@@ -67,7 +67,7 @@ A function can be developed to automatically send a conversation’s transcript 
 
 ### Use case 4: Integrate with a ticketing system with much greater flexibility
 
-Today, brands can integrate ticketing systems to empower agents with detailed and custom information about the consumers in a conversation. FaaS enables brands to take this integration further with full control over what information is passed and displayed to agents and what actions they can perform in the ticket as part of the conversation. For example, a ticketing integration will empower the agent to see the status of the consumer’s open ticket and take actions like closing or updating the ticket during the conversation with the consumer.
+Today, brands can integrate ticketing systems to empower agents with detailed and custom information about the consumers in a conversation. Functions enables brands to take this integration further with full control over what information is passed and displayed to agents and what actions they can perform in the ticket as part of the conversation. For example, a ticketing integration will empower the agent to see the status of the consumer’s open ticket and take actions like closing or updating the ticket during the conversation with the consumer.
 
 ### Use case 5: Leverage customer information to create alerts or actions
 
@@ -75,7 +75,7 @@ Using the consumer information passed from a CRM integration, a function can be 
 
 ## How does FaaS work?
 
-As part of the offering, LivePerson supplies an easy-to-use interface where brands and their developers can select an event to trigger a function. Once an event is selected, developers can either write custom functions or leverage FaaS templates for commonly used functions. Brands can set one or more triggers from events, and then automatically launch functions through LivePerson’s FaaS.
+As part of the offering, LivePerson supplies an easy-to-use interface where brands and their developers can select an event to trigger a function. Once an event is selected, developers can either write custom functions or leverage LivePerson Functions' templates for commonly used functions. Brands can set one or more triggers from events, and then automatically launch functions through Functions.
 
 These functions can be created and deployed in a matter of minutes, allowing brands to rapidly build new conversational experiences, such as: seamless connections to CRM to inform routing decisions, the ability for agents to schedule consumer follow-ups, automatic lookups of outstanding consumer tickets, and more. The simplicity and speed of building new functions also lets developers test and learn without waiting through lengthy deployment cycles.
 
@@ -83,7 +83,7 @@ These functions can be created and deployed in a matter of minutes, allowing bra
 
 LivePerson’s offering includes a secret storage feature that gives brands a self-service way to secure, manage and update confidential consumer data or credentials. Read more about [how the Vault stores secrets](https://developers.liveperson.com/function-as-a-service-developing-with-faas-storing-secrets.html#documenttitlecontainer).
 
-## Benefits of developing with FaaS
+## Benefits of developing with Functions
 
 **Simpler development**
 

--- a/pages/documents/Developer Tools/open-platform.md
+++ b/pages/documents/Developer Tools/open-platform.md
@@ -18,7 +18,7 @@ The LiveEngage platform offers a messaging solution that you can enhance by:
 * Integrating LiveEngage with your native app
 * Customizing LiveEngage reports or creating new reports
 * Building or integrating workspace widgets using our [various APIs and SDKs](https://developers.liveperson.com/index.html)
-* Developing custom behaviors within the LiveEngage platform through [Function as a Service (FaaS)](https://developers.liveperson.com/function-as-a-service-overview.html)
+* Developing custom behaviors within the LiveEngage platform through LivePerson's FaaS platform [Functions](https://developers.liveperson.com/function-as-a-service-overview.html)
 
 Our APIs configure and manipulate LiveEngage features and capabilities. To use these APIs, you must make sure to configure your LiveEngage account to access these features. For example, if you want to use the Agent Messaging SDK to connect a bot, then your account must support bot users. It's best to contact your account team or LivePerson Support to check that the prerequisite features are enabled for your account. For more information and detailed documentation, visit our dedicated [Developers' Community](https://developers.liveperson.com/index.html).
 


### PR DESCRIPTION
Renamed FaaS to Functions due to the rebrand. New images were shared separately wit eden kupermintz.