### PR TITLE
Hotfix for gem lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,13 +24,11 @@ GEM
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
-    eventmachine (1.2.7-x64-mingw32)
     execjs (2.7.0)
     extras (0.3.0)
       forwardable-extended (~> 2.5)
     fastimage (2.2.2)
     ffi (1.14.2)
-    ffi (1.14.2-x64-mingw32)
     filesize (0.2.0)
     forwardable-extended (2.6.0)
     html-proofer (3.18.5)
@@ -80,7 +78,7 @@ GEM
       sprockets (>= 3.3, < 4.1.beta)
     jekyll-feed (0.15.1)
       jekyll (>= 3.7, < 5.0)
-    jekyll-gzip (2.5.0)
+    jekyll-gzip (2.5.1)
       jekyll (>= 3.0, < 5.0)
     jekyll-last-modified-at (1.3.0)
       jekyll (>= 3.7, < 5.0)
@@ -105,8 +103,6 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
     minitest (5.14.3)
-    nokogiri (1.11.1-x64-mingw32)
-      racc (~> 1.4)
     nokogiri (1.11.1-x86_64-darwin)
       racc (~> 1.4)
     nokogumbo (2.0.4)
@@ -142,8 +138,6 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
-  ruby
-  x64-mingw32
   x86_64-darwin-19
 
 DEPENDENCIES
@@ -162,4 +156,4 @@ DEPENDENCIES
   sprockets (~> 3.7)
 
 BUNDLED WITH
-   2.2.2
+   2.2.8


### PR DESCRIPTION
Create a new gem lock so there wouldn't be issues with old versions of gems